### PR TITLE
fix(LAP-689): enhance content/result reading

### DIFF
--- a/src/components/editor/local-custom-extensions/input-field/input-field.tsx
+++ b/src/components/editor/local-custom-extensions/input-field/input-field.tsx
@@ -6,6 +6,7 @@ import { AnswerContent } from "@/components/organisms/result/part-answers-card";
 import { Input } from "@/components/ui";
 import { useResult } from "@/hooks/zustand/use-result";
 import { useAnswerStore } from "@/hooks/zustand/use-simulated-test";
+import { genQuestionId } from "@/lib/utils";
 
 type CustomInputProps = Attribute & {
   questionNo: string;
@@ -22,7 +23,7 @@ const CustomInput = ({ questionNo }: CustomInputProps) => {
     <NodeViewWrapper className="mx-2 w-fit" contentEditable={false}>
       {answerKeys.length ? (
         <AnswerContent
-          id={`Question-${questionNo}`}
+          id={genQuestionId(questionNo)}
           questionNo={parseInt(questionNo)}
           answer={answerKeys[parseInt(questionNo) - 1]}
           userAnswer={value ?? ""}
@@ -32,7 +33,7 @@ const CustomInput = ({ questionNo }: CustomInputProps) => {
       ) : (
         <Input
           className="my-1 h-8 w-36 rounded-sm px-1.5 focus-visible:border-primary"
-          id={`Question-${questionNo}`}
+          id={genQuestionId(questionNo)}
           placeholder={`Question ${questionNo}`}
           onChange={(e) => {
             answer(parseInt(questionNo), e.target.value);

--- a/src/components/molecules/question-navigator-button.tsx
+++ b/src/components/molecules/question-navigator-button.tsx
@@ -1,7 +1,7 @@
 import { cva } from "class-variance-authority";
 
 import useSimulatedTestStore, { useAnswerStore } from "@/hooks/zustand/use-simulated-test";
-import { cn, scrollToElementById } from "@/lib/utils";
+import { cn, genQuestionId, scrollToElementById } from "@/lib/utils";
 
 const questionNavigatorVariants = cva(
   "size-7 rounded-[4px] text-center inline-grid place-items-center text-xs duration-200 transition-colors",
@@ -13,6 +13,8 @@ const questionNavigatorVariants = cva(
         unanswered: "bg-neutral-100/50 hover:bg-neutral-100/80",
         right: "bg-green-100 text-green-900 hover:bg-green-200/50",
         wrong: "bg-red-100 text-red-900 hover:bg-red-200/50",
+        rightActive: "bg-green-500 text-white hover:bg-green-500/80",
+        wrongActive: "bg-red-500 text-white hover:bg-red-500/80",
       },
     },
   }
@@ -34,28 +36,18 @@ const QuestionNavigatorButton = ({
   const { navigateToPart } = useSimulatedTestStore();
   const { answerSheet, currentQuestion, setCurrentQuestion } = useAnswerStore();
 
+  const handleNavigation = () => {
+    navigateToPart(number, partNo);
+    scrollToElementById(genQuestionId(number));
+    setCurrentQuestion(number);
+  };
+
+  const statusVariant = determineStatus(number, currentQuestion, answerSheet, status);
+
   return (
     <button
-      onClick={() => {
-        navigateToPart(number, partNo);
-        scrollToElementById(`Question-${number}`);
-        setCurrentQuestion(number);
-      }}
-      className={cn(
-        questionNavigatorVariants({
-          status:
-            status === undefined
-              ? number.toString() == currentQuestion.toString()
-                ? "active"
-                : answerSheet[number] == null || answerSheet[number] === undefined
-                  ? "unanswered"
-                  : "answered"
-              : status
-                ? "right"
-                : "wrong",
-        }),
-        className
-      )}
+      onClick={handleNavigation}
+      className={cn(questionNavigatorVariants({ status: statusVariant }), className)}
       {...props}
     >
       {number}
@@ -64,3 +56,25 @@ const QuestionNavigatorButton = ({
 };
 
 export default QuestionNavigatorButton;
+
+function determineStatus(
+  number: number,
+  currentQuestion: number,
+  answerSheet: Record<string, string | null>,
+  status?: boolean
+) {
+  if (status !== undefined) {
+    return number === currentQuestion
+      ? status
+        ? "rightActive"
+        : "wrongActive"
+      : status
+        ? "right"
+        : "wrong";
+  }
+
+  if (number === currentQuestion) return "active";
+  if (!answerSheet[number]) return "unanswered";
+
+  return "answered";
+}

--- a/src/components/organisms/question-groups/matching-headings-question-group.tsx
+++ b/src/components/organisms/question-groups/matching-headings-question-group.tsx
@@ -4,6 +4,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { useResult } from "@/hooks/zustand/use-result";
 import { useAnswerStore } from "@/hooks/zustand/use-simulated-test";
 import { QuestionGroupMatchingHeadings } from "@/lib/types/simulated-test.type";
+import { genQuestionId } from "@/lib/utils";
 
 import AnswerGuidanceContent from "../result/answer-guidance-content";
 
@@ -19,11 +20,7 @@ export default function MatchingHeadingsQuestionGroup({
     <div>
       <h6 className="font-bold">{questionCard}</h6>
       {questions.map((question) => (
-        <div
-          key={question.questionNo}
-          className="mt-4"
-          id={`Question-${question.questionNo.toString()}`}
-        >
+        <div key={question.questionNo} className="mt-4" id={genQuestionId(question.questionNo)}>
           <p>
             <strong className="mr-2">{question.questionNo}.</strong>
             {question.question}

--- a/src/components/organisms/question-groups/matching-information-question-group.tsx
+++ b/src/components/organisms/question-groups/matching-information-question-group.tsx
@@ -4,6 +4,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { useResult } from "@/hooks/zustand/use-result";
 import { useAnswerStore } from "@/hooks/zustand/use-simulated-test";
 import { QuestionGroupMatchingInformation } from "@/lib/types/simulated-test.type";
+import { genQuestionId } from "@/lib/utils";
 
 import AnswerGuidanceContent from "../result/answer-guidance-content";
 
@@ -31,11 +32,7 @@ export default function MatchingInformationQuestionGroup({
         ))}
       </ul>
       {questions.map((question) => (
-        <div
-          key={question.questionNo}
-          className="mt-4"
-          id={`Question-${question.questionNo.toString()}`}
-        >
+        <div key={question.questionNo} className="mt-4" id={genQuestionId(question.questionNo)}>
           <p>
             <strong className="mr-2">{question.questionNo}.</strong>
             {question.question}

--- a/src/components/pages/result/index.tsx
+++ b/src/components/pages/result/index.tsx
@@ -7,7 +7,7 @@ import {
   useGetSTSessionDetail,
 } from "@/hooks/react-query/use-simulated-test";
 import { useResult } from "@/hooks/zustand/use-result";
-import useSimulatedTestState from "@/hooks/zustand/use-simulated-test";
+import useSimulatedTestState, { useAnswerStore } from "@/hooks/zustand/use-simulated-test";
 import { EnumSimulatedTestSessionStatus, EnumSkill } from "@/lib/enums";
 import { SimulatedTestSession } from "@/lib/types/simulated-test.type";
 import { Route } from "@/routes/_authenticated/_dashboard/practice/simulated-test/result";
@@ -38,6 +38,7 @@ export default function ResultPage() {
     !isLoading
   );
   const { setAnswerKeys, setGuidances, setStatus, reset } = useResult();
+  const { resetAnswers } = useAnswerStore();
   const { resetTest } = useSimulatedTestState();
 
   useEffect(() => {
@@ -64,6 +65,11 @@ export default function ResultPage() {
     resetTest();
   };
 
+  const onDialogClose = () => {
+    reset();
+    resetAnswers();
+  };
+
   return (
     <div className="flex flex-col gap-6 p-4 pt-8">
       <ResultHeader collectionId={simulatedTest?.collectionId || 0} session={session} />
@@ -80,7 +86,7 @@ export default function ResultPage() {
               <TabsTrigger value="analysis">{t("analysis")}</TabsTrigger>
             </TabsList>
             {isAvailableSkill && (
-              <Dialog onOpenChange={(open) => !open && reset()}>
+              <Dialog onOpenChange={(open) => !open && onDialogClose()}>
                 <DialogTrigger asChild>
                   <Button variant="link" onClick={onDialogOpen}>
                     {t("detail.button")}

--- a/src/components/pages/simulated-test/listening.tsx
+++ b/src/components/pages/simulated-test/listening.tsx
@@ -7,7 +7,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { useGetSkillTestData, useGetSTSessionDetail } from "@/hooks/react-query/use-simulated-test";
 import useSimulatedTestState from "@/hooks/zustand/use-simulated-test";
 import { STSkillPageProps } from "@/lib/types/simulated-test.type";
-import { scrollToElementById } from "@/lib/utils";
+import { genQuestionId, scrollToElementById } from "@/lib/utils";
 // import questionGroup from "@/lib/mock/mockListening1.json";
 // import { QuestionGroup } from "@/lib/types/simulated-test.type";
 
@@ -20,7 +20,7 @@ const ListeningPage = ({ skillTestId, sessionId }: STSkillPageProps) => {
 
   useEffect(() => {
     if (!isLoading) {
-      scrollToElementById(`Question-${question}`);
+      scrollToElementById(genQuestionId(question));
     }
   }, [isLoading, question]);
 

--- a/src/components/pages/simulated-test/reading.tsx
+++ b/src/components/pages/simulated-test/reading.tsx
@@ -9,7 +9,7 @@ import { useGetSkillTestData, useGetSTSessionDetail } from "@/hooks/react-query/
 import useBreakPoint from "@/hooks/use-screen-size";
 import useSimulatedTestState from "@/hooks/zustand/use-simulated-test";
 import { STSkillPageProps } from "@/lib/types/simulated-test.type";
-import { scrollToElementById } from "@/lib/utils";
+import { genQuestionId, scrollToElementById } from "@/lib/utils";
 
 const ReadingPage = ({ skillTestId, sessionId }: STSkillPageProps) => {
   const {
@@ -21,7 +21,7 @@ const ReadingPage = ({ skillTestId, sessionId }: STSkillPageProps) => {
 
   useEffect(() => {
     if (!isLoading) {
-      scrollToElementById(`Question-${question}`);
+      scrollToElementById(genQuestionId(question));
     }
   }, [isLoading, question]);
 

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -4,25 +4,32 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-const Checkbox = React.forwardRef<
-  React.ElementRef<typeof CheckboxPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
->(({ className, ...props }, ref) => (
-  <CheckboxPrimitive.Root
-    ref={ref}
-    className={cn(
-      "peer size-4 shrink-0 overflow-clip rounded-sm border border-neutral-600 shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed",
-      className
-    )}
-    {...props}
-  >
-    <CheckboxPrimitive.Indicator
-      className={cn("flex size-4 items-center justify-center bg-primary/40")}
+interface CheckboxProps extends React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root> {
+  status?: boolean;
+}
+
+const Checkbox = React.forwardRef<React.ElementRef<typeof CheckboxPrimitive.Root>, CheckboxProps>(
+  ({ className, status, ...props }, ref) => (
+    <CheckboxPrimitive.Root
+      ref={ref}
+      className={cn(
+        "peer size-4 shrink-0 overflow-clip rounded-sm border shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed",
+        status ? "border-green-600" : status === false ? "border-red-600" : "border-neutral-600",
+        className
+      )}
+      {...props}
     >
-      <CheckIcon />
-    </CheckboxPrimitive.Indicator>
-  </CheckboxPrimitive.Root>
-));
+      <CheckboxPrimitive.Indicator
+        className={cn(
+          "flex size-4 items-center justify-center",
+          status ? "bg-green-200" : status === false ? "bg-red-200" : "bg-primary/40"
+        )}
+      >
+        <CheckIcon />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+);
 Checkbox.displayName = CheckboxPrimitive.Root.displayName;
 
 export { Checkbox };

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -4,9 +4,7 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-const labelVariants = cva(
-  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-);
+const labelVariants = cva("text-sm font-medium leading-none peer-disabled:cursor-not-allowed");
 
 const Label = React.forwardRef<
   React.ElementRef<typeof LabelPrimitive.Root>,

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -153,3 +153,7 @@ export const checkRoutePermission = (pathname: string, userRole: EnumRole) => {
   }
   return true;
 };
+
+export const genQuestionId = (questionNo: number | string) => {
+  return `Question-${questionNo}`;
+};


### PR DESCRIPTION
## Summary
<!--- Add some bells and whistles for PR template. --->
- make utils function for gen question id
- enhance ui for showing answer status of multiple choices
- fix call answer multiple choice at default cause wrong current question
- update reset when close result dialog

## Test Plan
<!--- Please input steps on how to test this PR, including evidence in the form of captured images or videos. If this is not necessary, provide the reason why. --->
- Show A. B. C. D. for multiple choice options.
- Show the correct state for the check box 
![image](https://github.com/user-attachments/assets/da77152f-e4b0-4604-a534-757ce8bc45a4)
- Show the correct state for the navigation button, align with the active state
![image](https://github.com/user-attachments/assets/e622a0fb-c293-4911-8736-c7e5e7a7454d)
- The footer navigates correctly and works right when re-open dialog or when starting the test after view the result.
- Simulated test still works correctly.

## Related Issues
<!---Add a reference section for management tickets, and relevant conversations.--->
https://datn.atlassian.net/browse/LAP-689

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply --->
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🕷 Bug fix (non-breaking change which fixes an issue)
- [ ] 👏 Performance optimization (non-breaking change which addresses a performance issue)
- [ ] 🛠 Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] 📗 Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] 📝 Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] ✅ Test (non-breaking change related to testing)
- [ ] 🔒 Security awareness (changes that effect permission scope, security scenarios)
