### PR TITLE
feat(LAP-816): add matching information to paragraph

### DIFF
--- a/src/components/organisms/question-groups/fill-in-blanks-question-group.tsx
+++ b/src/components/organisms/question-groups/fill-in-blanks-question-group.tsx
@@ -25,12 +25,9 @@ const extensions = [
   TableRow,
 ];
 
-export default function FillInBlanksQuestionGroup({
-  questions,
-  questionCard,
-}: QuestionGroupFillInBlanks) {
+export default function FillInBlanksQuestionGroup({ questions }: QuestionGroupFillInBlanks) {
   const editor = new Editor({
-    extensions: extensions,
+    extensions,
     content: questions,
     editable: false,
     injectCSS: false,
@@ -38,7 +35,6 @@ export default function FillInBlanksQuestionGroup({
 
   return (
     <div>
-      <h6 className="mb-4 font-bold">{questionCard}</h6>
       <EditorContent editor={editor} autoComplete="off" />
     </div>
   );

--- a/src/components/organisms/question-groups/helpers.ts
+++ b/src/components/organisms/question-groups/helpers.ts
@@ -1,5 +1,5 @@
 import { EnumQuestionGroup } from "@/lib/enums";
-import { QuestionGroupMultipleChoice } from "@/lib/types";
+import { QuestionGroupMatchingHeadings, QuestionGroupMultipleChoice } from "@/lib/types";
 
 const getTFNGQuestions = (questions: QuestionGroupMultipleChoice["questions"]) => {
   return questions.map((question) => {
@@ -59,4 +59,22 @@ const getQuestions = (
   }
 };
 
-export { getQuestions };
+const getMatchingInformationToParagraphQuestions = (
+  questions: QuestionGroupMatchingHeadings["questions"],
+  numberOfParagraphs: QuestionGroupMatchingHeadings["numberOfParagraphs"] = 0
+) => {
+  const listOfOptions = Array.from({ length: numberOfParagraphs }, (_, index) => {
+    return {
+      value: String.fromCharCode(65 + index), // 65 is the char code for 'A'
+      label: `Paragraph ${String.fromCharCode(65 + index)}`,
+    };
+  });
+
+  return questions.map((question) => {
+    return {
+      ...question,
+      options: listOfOptions,
+    };
+  });
+};
+export { getMatchingInformationToParagraphQuestions, getQuestions };

--- a/src/components/organisms/question-groups/index.tsx
+++ b/src/components/organisms/question-groups/index.tsx
@@ -1,3 +1,5 @@
+import parser from "html-react-parser";
+
 import { EnumQuestionGroup } from "@/lib/enums";
 import { QuestionGroup } from "@/lib/types/simulated-test.type";
 
@@ -14,16 +16,41 @@ const QuestionGroupFactory = ({ questionGroup }: QuestionGroupFactoryProps) => {
   switch (questionGroup.questionType) {
     case EnumQuestionGroup.fillInBlanks:
       return <FillInBlanksQuestionGroup {...questionGroup} />;
+
     case EnumQuestionGroup.matchingHeadings:
+    case EnumQuestionGroup.matchingInformationToParagraph:
       return <MatchingHeadingsQuestionGroup {...questionGroup} />;
+
     case EnumQuestionGroup.multipleChoice:
     case EnumQuestionGroup.TFNG:
     case EnumQuestionGroup.YNNG:
       return <MultipleChoiceQuestionGroup {...questionGroup} />;
+
     case EnumQuestionGroup.matchingInformation:
       return <MatchingInformationQuestionGroup {...questionGroup} />;
     default:
       return <div>Haven't supported yet</div>;
   }
 };
-export default QuestionGroupFactory;
+
+const QuestionGroupTemplate = ({ questionGroup }: { questionGroup: QuestionGroup }) => {
+  const { imageSrc, startQuestionNo, endQuestionNo, questionCard, questionDescription } =
+    questionGroup;
+  return (
+    <div>
+      <div className="mb-2 font-bold">
+        Question {startQuestionNo} - {endQuestionNo}.
+      </div>
+      <h6 className="mb-2 font-bold">{questionCard}</h6>
+      {questionDescription && typeof questionDescription == "string" && (
+        <div className="mb-2">{parser(questionDescription)}</div>
+      )}
+      {imageSrc ? (
+        <img src={imageSrc} alt={`Image ${startQuestionNo}-${endQuestionNo}`} className="w-1/2" />
+      ) : null}
+      <QuestionGroupFactory questionGroup={questionGroup} />
+    </div>
+  );
+};
+
+export default QuestionGroupTemplate;

--- a/src/components/organisms/question-groups/matching-headings-question-group.tsx
+++ b/src/components/organisms/question-groups/matching-headings-question-group.tsx
@@ -4,25 +4,30 @@ import BubbleQuestionIndex from "@/components/molecules/bubble-question-index";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui";
 import { useResult } from "@/hooks/zustand/use-result";
 import { useAnswerStore } from "@/hooks/zustand/use-simulated-test";
+import { EnumQuestionGroup } from "@/lib/enums";
 import { QuestionGroupMatchingHeadings } from "@/lib/types/simulated-test.type";
 import { genQuestionId } from "@/lib/utils";
 
 import AnswerGuidanceContent from "../result/answer-guidance-content";
+import { getMatchingInformationToParagraphQuestions } from "./helpers";
 
 export default function MatchingHeadingsQuestionGroup({
-  questionCard,
   questions,
-  imageSrc,
+  questionType,
+  numberOfParagraphs,
 }: QuestionGroupMatchingHeadings) {
   const { answer, answerSheet } = useAnswerStore();
   const { t } = useTranslation("collection");
   const { answerKeys, status, guidances } = useResult();
 
+  const modifiedQuestions =
+    questionType === EnumQuestionGroup.matchingInformationToParagraph
+      ? getMatchingInformationToParagraphQuestions(questions, numberOfParagraphs)
+      : questions;
+
   return (
     <div>
-      <h6 className="font-bold">{questionCard}</h6>
-      {imageSrc ? <img src={imageSrc} alt="Matching headings" className="w-1/2" /> : null}
-      {questions.map((question) => (
+      {modifiedQuestions.map((question) => (
         <div key={question.questionNo} className="mt-4" id={genQuestionId(question.questionNo)}>
           <p>
             <BubbleQuestionIndex index={question.questionNo} className="mb-2 mr-2" />

--- a/src/components/organisms/question-groups/matching-information-question-group.tsx
+++ b/src/components/organisms/question-groups/matching-information-question-group.tsx
@@ -10,11 +10,8 @@ import { genQuestionId } from "@/lib/utils";
 import AnswerGuidanceContent from "../result/answer-guidance-content";
 
 export default function MatchingInformationQuestionGroup({
-  questionCard,
   questions,
   options,
-  questionDescription,
-  imageSrc,
 }: QuestionGroupMatchingInformation) {
   const { answer, answerSheet } = useAnswerStore();
   const { t } = useTranslation("collection");
@@ -22,11 +19,6 @@ export default function MatchingInformationQuestionGroup({
 
   return (
     <div>
-      <h6 className="font-bold">{questionCard}</h6>
-      {imageSrc ? <img src={imageSrc} alt="Matching headings" className="w-1/2" /> : null}
-      {questionDescription && typeof questionDescription == "string" && (
-        <p className="my-2">{questionDescription}</p>
-      )}
       <ul className="ml-4 flex flex-col gap-2">
         {options.map((option) => (
           <li key={option.value}>

--- a/src/components/organisms/question-groups/multiple-choice-question-group.tsx
+++ b/src/components/organisms/question-groups/multiple-choice-question-group.tsx
@@ -75,7 +75,6 @@ function MultipleSelect({ question, disabled, questionStatus }: MultipleSelectPr
 }
 
 export default function MultipleChoiceQuestionGroup({
-  questionCard,
   questions,
   questionType,
 }: QuestionGroupMultipleChoice) {
@@ -89,7 +88,6 @@ export default function MultipleChoiceQuestionGroup({
 
   return (
     <div>
-      <h6 className="font-bold">{questionCard}</h6>
       {questionType === EnumQuestionGroup.TFNG && (
         <ul className="pl-4 pt-2 italic">
           <li>

--- a/src/components/pages/simulated-test/footer.tsx
+++ b/src/components/pages/simulated-test/footer.tsx
@@ -1,5 +1,5 @@
 import { ArrowLeft, ArrowRight } from "lucide-react";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import QuestionNavigator from "@/components/molecules/question-navigator-button";
@@ -70,7 +70,7 @@ const Footer = ({ partDetails, skill, answerStatus }: FooterProps) => {
       {skill !== EnumSkill.writing && (
         <div className="question-navigator flex h-fit w-full flex-1 flex-wrap items-center gap-1">
           {partDetails.map((group) => (
-            <React.Fragment key={group.part}>
+            <div key={group.part} className="flex flex-row items-center gap-1">
               <p className="w-[60px] text-center text-xs font-medium">Part {group.part}</p>
               {Array.from(
                 { length: group.endQuestionNo - group.startQuestionNo + 1 },
@@ -83,7 +83,7 @@ const Footer = ({ partDetails, skill, answerStatus }: FooterProps) => {
                   status={Array.isArray(answerStatus) ? answerStatus[number - 1] : answerStatus}
                 />
               ))}
-            </React.Fragment>
+            </div>
           ))}
         </div>
       )}

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -20,13 +20,13 @@ const RadioGroupItem = React.forwardRef<
     <RadioGroupPrimitive.Item
       ref={ref}
       className={cn(
-        "aspect-square size-4 rounded-full border border-neutral-500 text-primary shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed",
+        "aspect-square size-4 rounded-full border border-neutral-200 p-0 text-blue-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed [&[data-state=checked]>span]:bg-blue-300 [&>span]:rounded-full",
         className
       )}
       {...props}
     >
-      <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
-        <Circle className="size-2 fill-primary" />
+      <RadioGroupPrimitive.Indicator className="flex h-full items-center justify-center">
+        <Circle className="size-2 fill-white" />
       </RadioGroupPrimitive.Indicator>
     </RadioGroupPrimitive.Item>
   );

--- a/src/lib/enums.ts
+++ b/src/lib/enums.ts
@@ -65,6 +65,7 @@ export enum EnumQuestionGroup {
   multipleChoice = "multiple_choice",
   matchingHeadings = "matching_headings",
   matchingInformation = "matching_information",
+  matchingInformationToParagraph = "matching_information_to_paragraph",
   fillInBlanks = "fill_in_blanks",
   TFNG = "true_false_not_given",
   YNNG = "yes_no_not_given",
@@ -73,18 +74,8 @@ export enum EnumQuestionGroup {
 export enum EnumQuestionGroupLabel {
   // Multiple choice group
   // Output: A, B, C, D, E, F, G,... or True, False, Not Given or Yes, No, Not Given
-  multipleChoice = "multiple_choice",
-  TFNG = "true_false_not_given",
-  YNNG = "yes_no_not_given",
   listOfOptions = "list_of_options",
 
-  // Fill in the blanks group
-  // Output: short text
-  summaryFlowChartCompletion = "summary_flow_chart_completion",
-  noteFormCompletion = "note_form_completion",
-  tableCompletion = "table_completion",
-  mapPlanDiagramLabelling = "map_plan_diagram_labelling",
-  tableNoteFlowChartCompletion = "table_note_flow_chart_completion",
   shortAnswer = "short_answer",
   diagramLabelCompletion = "diagram_label_completion",
   summaryCompletion = "summary_completion",
@@ -95,7 +86,6 @@ export enum EnumQuestionGroupLabel {
   matchingInformation = "matching_information",
   matchingFeatures = "matching_features",
   matchingHeadings = "matching_headings",
-  matchingInformationToParagraph = "matching_information_to_paragraph",
   matchingSentenceEndings = "matching_sentence_endings",
 }
 

--- a/src/lib/types/simulated-test.type.ts
+++ b/src/lib/types/simulated-test.type.ts
@@ -55,6 +55,7 @@ type BaseQuestionGroup = {
   startQuestionNo: number;
   endQuestionNo: number;
   imageSrc?: string;
+  questionDescription?: string;
 };
 
 export type QuestionGroupMultipleChoice = BaseQuestionGroup & {
@@ -80,13 +81,15 @@ type MatchingHeadingsQuestion = {
 };
 
 export type QuestionGroupMatchingHeadings = BaseQuestionGroup & {
-  questionType: EnumQuestionGroup.matchingHeadings;
+  questionType:
+    | EnumQuestionGroup.matchingHeadings
+    | EnumQuestionGroup.matchingInformationToParagraph;
   questions: MatchingHeadingsQuestion[];
+  numberOfParagraphs?: number;
 };
 
 export type QuestionGroupMatchingInformation = BaseQuestionGroup & {
   questionType: EnumQuestionGroup.matchingInformation;
-  questionDescription: string | JSONContent | object;
   options: Option[];
   questions: {
     questionNo: number;


### PR DESCRIPTION
## Summary
<!--- Add some bells and whistles for PR template. --->
- Extract template for questionCard, questionDescription and imgSrc outside the scope of questionGroup
- Introduce type `matching_information_to_paragraph` to reduce the effort of writing list of options: Paragraph A, paragraph B, etc.

## Test Plan
<!--- Please input steps on how to test this PR, including evidence in the form of captured images or videos. If this is not necessary, provide the reason why. --->

## Related Issues
<!---Add a reference section for management tickets, and relevant conversations.--->
https://datn.atlassian.net/browse/LAP-816

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply --->
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🕷 Bug fix (non-breaking change which fixes an issue)
- [ ] 👏 Performance optimization (non-breaking change which addresses a performance issue)
- [ ] 🛠 Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] 📗 Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] 📝 Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] ✅ Test (non-breaking change related to testing)
- [ ] 🔒 Security awareness (changes that effect permission scope, security scenarios)
